### PR TITLE
Use http_archive not git_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ load("@rules_python_external//:defs.bzl", "pip_repository")
 
 pip_repository(
     name = "py_deps",
-    requirements = "//third_party:requirements.txt",
+    requirements = "//:requirements.txt",
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,26 +11,27 @@ boto3==1.9.253
 ```
 
 In `WORKSPACE`
+
 ```
 rules_python_external_version = "{COMMIT_SHA}"
 
-git_repository(
+http_archive(
     name = "rules_python_external",
-    commit = rules_python_external_version,
-    remote = "git@github.com:dillon-giacoppo/rules_python_external.git",
-    shallow_since = "1572846707 +1100",
+    sha256 = "", # Fill in with correct sha256 of your COMMIT_SHA version
+    strip_prefix = "rules_python_external-{version}".format(version = rules_python_external_version),
+    url = "https://github.com/dillon-giacoppo/rules_python_external/archive/{version}.zip".format(version = rules_python_external_version),
 )
-
 
 load("@rules_python_external//:defs.bzl", "pip_repository")
 
 pip_repository(
     name = "py_deps",
-    requirements = "//:requirements.txt",
+    requirements = "//third_party:requirements.txt",
 )
 ```
 
-In `BUILD`
+Example `BUILD` file.
+
 ```
 load("@py_deps//:requirements.bzl", "requirement")
 


### PR DESCRIPTION
### Description 

Bazel official docs discourage `git_repository` now. 

I've referred to a `.git`. `canva/canva` refers to the `.tar.gz`. I don't know if there's any meaningful difference between the two. 