### PR TITLE
Make requirement.txt instructions more detailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ botocore~=1.12.247
 click~=7.0
 ```
 
-Can 'compiles' it so you get a transitively-closed `requirements.txt` like this, which should be passed to `pip_install` below:
+These above are the third-party packages you can directly import.
+
+`pip-compile` 'compiles' it so you get a transitively-closed `requirements.txt` like this, which should be passed to `pip_install` below:
 
 ```
 boto3==1.9.253
@@ -67,6 +69,8 @@ py_binary(
     ],
 )
 ```
+
+Note that above you do not need to add transitively required packages to `deps = [ ... ]`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,34 @@ Contains Bazel rules to fetch and install Python dependencies from a requirement
 
 ## Usage
 
-In `requirements.txt`
+#### Setup `requirements.txt` 
+
+`rules_python_external` requires a _transitively-closed_ `requirements.txt` file, which would
+be very tedious to produce and maintain manually. To automate the process we recommend [`pip-compile` from `jazzband/pip-tools`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile).
+
+For example, `pip-compile` takes a `requirements.in` like this:
+
 ```
-cryptography==2.8
-boto3==1.9.253
+boto3~=1.9.227
+botocore~=1.12.247
+click~=7.0
 ```
 
-In `WORKSPACE`
+Can 'compiles' it so you get a transitively-closed `requirements.txt` like this, which should be passed to `pip_install` below:
+
+```
+boto3==1.9.253
+botocore==1.12.253
+click==7.0
+docutils==0.15.2          # via botocore
+jmespath==0.9.4           # via boto3, botocore
+python-dateutil==2.8.1    # via botocore
+s3transfer==0.2.1         # via boto3
+six==1.14.0               # via python-dateutil
+urllib3==1.25.8           # via botocore
+```
+
+#### Setup `WORKSPACE`
 
 ```python
 rules_python_external_version = "{COMMIT_SHA}"


### PR DESCRIPTION
### Description

Had a person express some confusion to me in the Bazelbuild Slack:

> Is it clear whether `r_p_e` resolves transitive dependencies? I ended up running them all down and including them by hand in my requirements.txt just to eliminate sources of uncertainty while I was thrashing through my config.

In response to this I've made this change that makes the `README` instructions more detailed.