### PR TITLE
Init README Adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ Note that above you do not need to add transitively required packages to `deps =
 ### Testing
 
 `bazel test //...`
+
+## Adopters
+
+Here's a (non-exhaustive) list of companies that use `rules_python_external` in production. Don't see yours? [You can add it in a PR](https://github.com/dillon-giacoppo/rules_python_external/edit/master/README.md)!
+
+* [Canva](https://www.canva.com/)


### PR DESCRIPTION
### Description

This is a reasonably common thing to have in Bazel community projects. Lends some cred.