### PR TITLE
Allow for optionally extending the max time the pypi fetching repoctx action can last

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -44,6 +44,7 @@ pip_repository = repository_rule(
         "requirements": attr.label(allow_single_file=True, mandatory=True,),
         "wheel_env": attr.string_dict(),
         "python_interpreter": attr.string(default="python3"),
+        # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
         "timeout": attr.int(default = 600),
         "_script": attr.label(
             executable=True, default=Label("//src:__main__.py"), cfg="host",

--- a/defs.bzl
+++ b/defs.bzl
@@ -31,6 +31,7 @@ def _pip_repository_impl(rctx):
             # Manually construct the PYTHONPATH since we cannot use the toolchain here
             "PYTHONPATH": pypath
         },
+        timeout=rctx.attr.timeout,
     )
     if result.return_code:
         fail("rules_python_external failed: %s (%s)" % (result.stdout, result.stderr))
@@ -43,6 +44,7 @@ pip_repository = repository_rule(
         "requirements": attr.label(allow_single_file=True, mandatory=True,),
         "wheel_env": attr.string_dict(),
         "python_interpreter": attr.string(default="python3"),
+        "timeout": attr.int(default = 600),
         "_script": attr.label(
             executable=True, default=Label("//src:__main__.py"), cfg="host",
         ),


### PR DESCRIPTION
### Description 

In the DS repo we're experiencing timeouts. 

There's [precedent for this here](https://github.com/bazelbuild/rules_python/pull/236). 

If we add the option to say that your `requirements.txt` is already transitively resolved we can do parallel fetching like https://github.com/ali5h/rules_pip does. 