### PR TITLE
Reinstate function that was erroneously removed

### DIFF
--- a/src/extract_wheels.py
+++ b/src/extract_wheels.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-from src import wheel, namespace_pkgs
+from src import wheel, namespace_pkgs, purelib
 
 BUILD_TEMPLATE = """\
 package(default_visibility = ["//visibility:public"])
@@ -71,6 +71,8 @@ def extract_wheel(whl, directory, extras):
 
     whl.unzip(directory)
 
+    # Note: Order of operations matters here
+    purelib.spread_purelib_into_root(directory)
     _setup_namespace_pkg_compatibility(directory)
 
     with open(os.path.join(directory, "BUILD"), "w") as f:


### PR DESCRIPTION
### Description

Here we lost a function that we needed: https://github.com/dillon-giacoppo/rules_python_external/commit/12bfbdffc57bbaf9a3de31e6a7acdc415eb9de72#diff-fd1f6b9cc2a83b11b2e67dcdd20c6a77L82

We noticed on Friday that some tests using `xgboost` were now failing locally. Used `git bisect` to track it to a commit `Use latest master of rules_python_external, that lets you set a longer timeout on pypi fetching (#4261)`. 

cc @groodt 

