### PR TITLE
Remove dependency cycle

### DIFF
--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 
-from extract_wheels.lib import wheel, bazel
+from extract_wheels.lib import bazel
 
 
 def configure_reproducible_wheels() -> None:
@@ -71,7 +71,7 @@ def main() -> None:
     )
 
     targets = [
-        '"%s%s"' % (args.repo, wheel.extract_wheel(whl, []))
+        '"%s%s"' % (args.repo, bazel.extract_wheel(whl, []))
         for whl in glob.glob("*.whl")
     ]
 


### PR DESCRIPTION
Linters weren't running correctly due to a missing `__init__.py`. Run through flake8 and pylint and identified a dependency cycle.

Fixed by moving `extract_wheel` to `bazel.py` which makes sense considering it is tailored for `bazel`.

Will cause a merge conflict with https://github.com/dillon-giacoppo/rules_python_external/pull/28 so will rebase on merge.