### PR TITLE
[WIP] Faster pip package fetching

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -21,16 +21,20 @@ def _pip_repository_impl(rctx):
     ]
     pypath = ":".join([str(p) for p in [rules_root] + thirdparty_roots])
 
+    args = [
+        python_interpreter,
+        "-m",
+        "extract_wheels",
+        "--requirements",
+        rctx.path(rctx.attr.requirements),
+        "--repo",
+        "@%s" % rctx.attr.name,
+    ]
+    if rctx.attr.precompiled:
+        args += ["--precompiled"]
+
     result = rctx.execute(
-        [
-            python_interpreter,
-            "-m",
-            "extract_wheels",
-            "--requirements",
-            rctx.path(rctx.attr.requirements),
-            "--repo",
-            "@%s" % rctx.attr.name,
-        ],
+        args,
         environment={
             # Manually construct the PYTHONPATH since we cannot use the toolchain here
             "PYTHONPATH": pypath
@@ -50,6 +54,7 @@ pip_repository = repository_rule(
         "python_interpreter": attr.string(default="python3"),
         # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
         "timeout": attr.int(default = 600),
+        "precompiled": attr.bool(default = False),
     },
     implementation=_pip_repository_impl,
 )

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -39,17 +39,6 @@ def configure_reproducible_wheels() -> None:
     if "PYTHONHASHSEED" not in os.environ:
         os.environ["PYTHONHASHSEED"] = "0"
 
-def _fetch_packages_parallel(requirements_filepath):
-    from pip._internal.req.req_file import parse_requirements
-    from pip._internal.download import PipSession
-    from multiprocessing import Process
-    reqs = parse_requirements(requirements_filepath, session=PipSession())
-
-    # p = Process(target=f, args=('bob',))
-    # p.start()
-    # p.join()
-    raise RuntimeError(list(["{}{}".format(r.req.name, r.req.specifier) for r in reqs]))
-
 
 def main() -> None:
     """Main program.

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -39,6 +39,17 @@ def configure_reproducible_wheels() -> None:
     if "PYTHONHASHSEED" not in os.environ:
         os.environ["PYTHONHASHSEED"] = "0"
 
+def _fetch_packages_parallel(requirements_filepath):
+    from pip._internal.req.req_file import parse_requirements
+    from pip._internal.download import PipSession
+    from multiprocessing import Process
+    reqs = parse_requirements(requirements_filepath, session=PipSession())
+
+    # p = Process(target=f, args=('bob',))
+    # p.start()
+    # p.join()
+    raise RuntimeError(list(["{}{}".format(r.req.name, r.req.specifier) for r in reqs]))
+
 
 def main() -> None:
     """Main program.

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -74,12 +74,22 @@ def main() -> None:
         required=True,
         help="The external repo name to install dependencies. In the format '@{REPO_NAME}'",
     )
+    parser.add_argument(
+        "--precompiled",
+        action="store_true",
+        help="If set, assumes requirements.txt is a full transitive tree of locked dependencies. Enables parallel package fetching.",
+    )
     args = parser.parse_args()
 
+    wheel_cmd = [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
+    if args.precompiled:
+        # _fetch_packages_parallel(
+        #     requirements_filepath=args.requirements
+        # )
+        wheel_cmd.append("--no-deps")
+
     # Assumes any errors are logged by pip so do nothing. This command will fail if pip fails
-    subprocess.check_output(
-        [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
-    )
+    subprocess.check_output(wheel_cmd)
 
     extras = requirements.parse_extras(args.requirements)
 

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -110,14 +110,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    wheel_cmd = [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
     if args.precompiled:
         _fetch_packages_parallel(
             requirements_filepath=args.requirements
         )
     else:
         # Assumes any errors are logged by pip so do nothing. This command will fail if pip fails
-        subprocess.check_output(wheel_cmd)
+        subprocess.check_output([sys.executable, "-m", "pip", "wheel", "-r", args.requirements])
 
     extras = requirements.parse_extras(args.requirements)
 

--- a/tools/typing/mypy.ini
+++ b/tools/typing/mypy.ini
@@ -7,3 +7,6 @@ python_version = 3.5
 # https://mypy.readthedocs.io/en/latest/stubs.html
 [mypy-pkginfo.*]
 ignore_missing_imports = True
+
+[mypy-pip.*]
+ignore_missing_imports = True


### PR DESCRIPTION
🚧🚧 **WIP** 🚧🚧

**Current PR Status:** Significant performance gains on `bazel sync` using `concurrent.futures.ThreadPoolExecutor` to fetch wheels, but code is still messy and quite brittle.

---

Attempting to significantly speed up the fetching of dependencies. 

In #23 we added timeout extensions because our large `requirements.txt` was occasionally taking > 600 seconds to download and CI was failing. 

This PR wants to go further and have transitively-resolved and locked (ie. precompiled) `requirements.txt`s get downloaded a lot faster.