### PR TITLE
Fix pip_install

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -55,7 +55,7 @@ pip_repository = repository_rule(
 )
 
 
-def pip_install(requirements, name=DEFAULT_REPOSITORY_NAME):
+def pip_install(requirements, name=DEFAULT_REPOSITORY_NAME, **kwargs):
     pip_repository(
-        name=name, requirements=requirements,
+        name=name, requirements=requirements, **kwargs
     )


### PR DESCRIPTION
`pip_install` is a macro to future proof the rules so that we can transparently manipulate the underlying repository rule implementation. For example, r_j_e uses the macro to conditionally execute its pinning rules https://github.com/bazelbuild/rules_jvm_external/blob/master/defs.bzl#L121.

This macro was not passing kwargs correctly which means that the only way to use the additional config options is using the pip_repository directly, this should not be encouraged as it locks us into the existing behaviour. Unfortunately, it would be a breaking change to make the `pip_repository` rule private, i.e with _pip_repository, or to change it to an internal subpackage.

For now, we just fix `pip_install` and encourage its use in the README, as we currently do.
