### PR TITLE
create missing directory when creating package init file

### DIFF
--- a/extract_wheels/lib/namespace_pkgs.py
+++ b/extract_wheels/lib/namespace_pkgs.py
@@ -84,6 +84,8 @@ def add_pkgutil_style_namespace_pkg_init(dir_path: str) -> None:
 
     if os.path.isfile(ns_pkg_init_filepath):
         raise ValueError("%s already contains an __init__.py file." % dir_path)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
     with open(ns_pkg_init_filepath, "w") as ns_pkg_init_f:
         # See https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
         ns_pkg_init_f.write(

--- a/extract_wheels/lib/namespace_pkgs_test.py
+++ b/extract_wheels/lib/namespace_pkgs_test.py
@@ -131,5 +131,13 @@ class TestImplicitNamespacePackages(unittest.TestCase):
         self.assertEqual(actual, set())
 
 
+class TestaddPkgutilStyleNamespacePkgInit(unittest.TestCase):
+    def test_missing_directory_is_created(self):
+        directory = TempDir()
+        missing_directory = pathlib.Path(directory.root()) / "missing_directory"
+        namespace_pkgs.add_pkgutil_style_namespace_pkg_init(str(missing_directory))
+        self.assertTrue(missing_directory.is_dir())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When importing ruamel.yaml.clib the namespace init package creation fails because the directory does not exist.
ruamel.yaml.clib which is a dependency of ruamel.yaml and only contains a so-file that is placed in the root of site-packages but still defines "ruamel" in the namespace_packages. Therefore the creation of ruamel/__init__.py fails because of the directory ruamel is not contained in the whl.

An alternative solution would be to skip the creation of the __init__.py file when the directory is not present