### PR TITLE
Refactor construction of tempfile path

### DIFF
--- a/extract_wheels/lib/namespace_pkgs_test.py
+++ b/extract_wheels/lib/namespace_pkgs_test.py
@@ -133,8 +133,7 @@ class TestImplicitNamespacePackages(unittest.TestCase):
 
 class TestaddPkgutilStyleNamespacePkgInit(unittest.TestCase):
     def test_missing_directory_is_created(self):
-        directory = TempDir()
-        missing_directory = pathlib.Path(directory.root()) / "missing_directory"
+        missing_directory = pathlib.Path(TempDir().root(), "missing_directory")
         namespace_pkgs.add_pkgutil_style_namespace_pkg_init(str(missing_directory))
         self.assertTrue(missing_directory.is_dir())
 


### PR DESCRIPTION
If `x` is already an instance of `pathlib.Path`, then doing `z = x / "bar"` is quite nice. But if you're doing `z = pathlib.Path(something) / "bar"` then I'd prefer `z = pathlib.Path(something, "bar")`. 

If you disagree can close the PR. Not a big deal. 