### PR TITLE
Support python interpreter target in pip_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ load("@rules_python_external//:defs.bzl", "pip_install")
 pip_install(
     name = "py_deps",
     requirements = "//:requirements.txt",
+    # (Optional) You can provide a python interpreter (by path):
+    python_interpreter = "/usr/bin/python3.8",
+    # (Optional) Alternatively you can provide an in-build python interpreter, that is available as a Bazel target.
+    # This overrides `python_interpreter`.
+    # Note: You need to set up the interpreter target beforehand (not shown here). Please see the `example` folder for further details.
+    #python_interpreter_target = "@python_interpreter//:python_bin",
 )
 ```
 

--- a/example/BUILD
+++ b/example/BUILD
@@ -1,9 +1,33 @@
 load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_runtime_pair")
+
+# Toolchain setup, this is optional.
+# Demonstrate that we can use the same python interpreter for the toolchain and executing pip in pip install (see WORKSPACE).
+py_runtime(
+    name = "python3_runtime",
+    files = ["@python_interpreter//:files"],
+    interpreter = "@python_interpreter//:python_bin",
+    python_version = "PY3",
+    visibility = ["//visibility:public"],
+)
+
+py_runtime_pair(
+    name = "my_py_runtime_pair",
+    py2_runtime = None,
+    py3_runtime = ":python3_runtime",
+)
+
+toolchain(
+    name = "my_py_toolchain",
+    toolchain = ":my_py_runtime_pair",
+    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+)
+# End of toolchain setup.
 
 py_binary(
     name = "main",
     srcs = ["main.py"],
     deps = [
-        requirement("boto3")
+        requirement("boto3"),
     ],
 )

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -4,11 +4,51 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
     sha256 = "aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz",
 )
+
 load("@rules_python//python:repositories.bzl", "py_repositories")
+
 py_repositories()
+
+# You could optionally use an in-build, compiled python interpreter as a toolchain,
+# and also use it to execute pip.
+
+# Special logic for building python interpreter with OpenSSL from homebrew.
+# See https://devguide.python.org/setup/#macos-and-os-x
+_py_configure = """
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    ./configure --prefix=$(pwd)/bazel_install --with-openssl=$(brew --prefix openssl)
+else
+    ./configure --prefix=$(pwd)/bazel_install
+fi
+"""
+
+# NOTE: you need to have the SSL headers installed to build with openssl support (and use HTTPS).
+# E.g. on Ubuntu: `sudo apt install libssl-dev`
+http_archive(
+    name = "python_interpreter",
+    build_file_content = """
+exports_files(["python_bin"])
+filegroup(
+    name = "files",
+    srcs = glob(["bazel_install/**"], exclude = ["**/* *"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    patch_cmds = [
+        "mkdir $(pwd)/bazel_install",
+        _py_configure,
+        "make",
+        "make install",
+        "ln -s bazel_install/bin/python3 python_bin",
+    ],
+    sha256 = "dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864",
+    strip_prefix = "Python-3.8.3",
+    urls = ["https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tar.xz"],
+)
+# End of in-build Python interpreter setup.
 
 local_repository(
     name = "rules_python_external",
@@ -16,10 +56,22 @@ local_repository(
 )
 
 load("@rules_python_external//:repositories.bzl", "rules_python_external_dependencies")
+
 rules_python_external_dependencies()
 
 load("@rules_python_external//:defs.bzl", "pip_install")
+
 pip_install(
+    # You can optionally provide a python_interpreter (path) or a python_interpreter_target (a Bazel target, that
+    # acts as an executable). The latter can be anything that could be used as Python interpreter. E.g.:
+    # 1. Python interpreter that you compile in the build file (as above in @python_interpreter).
+    # 2. Pre-compiled python interpreter included with http_archive
+    # 3. Wrapper script, like in the autodetecting python toolchain.
+    python_interpreter_target = "@python_interpreter//:python_bin",
     # Uses the default repository name "pip"
     requirements = "//:requirements.txt",
 )
+
+# Optional:
+# Register the toolchain with the same python interpreter we used for pip in pip_install().
+register_toolchains("//:my_py_toolchain")


### PR DESCRIPTION
This allows users to use an in-build python interpreter instead of
a system one with pip_repository.
The in-build python interpreter can be one that is used through
http_archive or built by another repository rule.

Port of https://github.com/bazelbuild/rules_python/pull/312 made by @kku1993.