### PR TITLE
Fix errors with incompatible_disallow_empty_glob

### DIFF
--- a/extract_wheels/lib/bazel.py
+++ b/extract_wheels/lib/bazel.py
@@ -25,7 +25,7 @@ def generate_build_file_contents(name: str, dependencies: List[str]) -> str:
 
         py_library(
             name = "{name}",
-            srcs = glob(["**/*.py"]),
+            srcs = glob(["**/*.py"], allow_empty = True),
             data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
             # This makes this directory a top-level in the python import
             # search path for anything that depends on this.

--- a/extract_wheels/lib/bazel.py
+++ b/extract_wheels/lib/bazel.py
@@ -15,6 +15,9 @@ def generate_build_file_contents(name: str, dependencies: List[str]) -> str:
 
     Returns:
         A complete BUILD file as a string
+
+    We allow for empty Python sources as for Wheels containing only compiled C code
+    there may be no Python sources whatsoever (e.g. packages written in Cython: like `pymssql`).
     """
 
     return textwrap.dedent(


### PR DESCRIPTION
Allow py_library sources to be empty.
If --incompatible_disallow_empty_glob is set then generated py_library
targets will fail if there are no .py files.

Examples are pymssql==2.1.4 and cx-Oracle==7.2.3.

Set `allow_empty = True` for glob().

Bazel issue for incompatible_disallow_empty_glob:
https://github.com/bazelbuild/bazel/issues/8195