### PR TITLE
Add extra_pip_args to pip_repository

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -34,6 +34,12 @@ def _pip_repository_impl(rctx):
         "@%s" % rctx.attr.name,
     ]
 
+    if rctx.attr.extra_pip_args:
+        args += [
+            "--extra_pip_args",
+            "\"" + " ".join(rctx.attr.extra_pip_args) + "\"",
+        ]
+
     result = rctx.execute(
         args,
         environment = {
@@ -62,6 +68,9 @@ python_interpreter.
         # 600 is documented as default here: https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#execute
         "timeout": attr.int(default = 600),
         "quiet": attr.bool(default = True),
+        "extra_pip_args": attr.string_list(
+            doc = "Extra arguments to pass on to pip. Must not contain spaces.",
+        ),
     },
     implementation = _pip_repository_impl,
 )

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -63,9 +63,13 @@ def main() -> None:
         required=True,
         help="The external repo name to install dependencies. In the format '@{REPO_NAME}'",
     )
+    parser.add_argument('--extra_pip_args', action='store',
+                        help=('Extra arguments to pass down to pip.'))
     args = parser.parse_args()
 
     pip_args = [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
+    if args.extra_pip_args:
+        pip_args += args.extra_pip_args.strip("\"").split()
     # Assumes any errors are logged by pip so do nothing. This command will fail if pip fails
     subprocess.run(pip_args, check=True)
 


### PR DESCRIPTION
This enables special pip usage such as loading packages from an alternate repository or local directory.

Port of https://github.com/bazelbuild/rules_python/pull/274