### PR TITLE
Add pip_data_exclude to pip_repository

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -40,6 +40,15 @@ def _pip_repository_impl(rctx):
             "\"" + " ".join(rctx.attr.extra_pip_args) + "\"",
         ]
 
+    if rctx.attr.pip_data_exclude:
+        pip_data_exclude_quoted = []
+        for exclude_param in rctx.attr.pip_data_exclude:
+            pip_data_exclude_quoted.append("\"" + exclude_param + "\"")
+        args += [
+            "--pip_data_exclude",
+            "[" + ",".join(pip_data_exclude_quoted) + "]",
+        ]
+
     result = rctx.execute(
         args,
         environment = {
@@ -70,6 +79,9 @@ python_interpreter.
         "quiet": attr.bool(default = True),
         "extra_pip_args": attr.string_list(
             doc = "Extra arguments to pass on to pip. Must not contain spaces.",
+        ),
+        "pip_data_exclude": attr.string_list(
+            doc = "Additional data exclusion parameters to add to the pip packages BUILD file.",
         ),
     },
     implementation = _pip_repository_impl,

--- a/defs.bzl
+++ b/defs.bzl
@@ -41,12 +41,9 @@ def _pip_repository_impl(rctx):
         ]
 
     if rctx.attr.pip_data_exclude:
-        pip_data_exclude_quoted = []
-        for exclude_param in rctx.attr.pip_data_exclude:
-            pip_data_exclude_quoted.append("\"" + exclude_param + "\"")
         args += [
             "--pip_data_exclude",
-            "[" + ",".join(pip_data_exclude_quoted) + "]",
+            struct(exclude = rctx.attr.pip_data_exclude).to_json(),
         ]
 
     result = rctx.execute(

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -10,6 +10,7 @@ import glob
 import os
 import subprocess
 import sys
+import json
 
 from extract_wheels.lib import bazel, requirements
 
@@ -65,6 +66,11 @@ def main() -> None:
     )
     parser.add_argument('--extra_pip_args', action='store',
                         help=('Extra arguments to pass down to pip.'))
+    parser.add_argument(
+        "--pip_data_exclude",
+        action='store',
+        help='Additional data exclusion parameters to add to the pip packages BUILD file.'
+    )
     args = parser.parse_args()
 
     pip_args = [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
@@ -75,8 +81,13 @@ def main() -> None:
 
     extras = requirements.parse_extras(args.requirements)
 
+    if args.pip_data_exclude:
+        pip_data_exclude = json.loads(args.pip_data_exclude)
+    else:
+        pip_data_exclude = []
+
     targets = [
-        '"%s%s"' % (args.repo, bazel.extract_wheel(whl, extras))
+        '"%s%s"' % (args.repo, bazel.extract_wheel(whl, extras, pip_data_exclude))
         for whl in glob.glob("*.whl")
     ]
 

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -82,7 +82,7 @@ def main() -> None:
     extras = requirements.parse_extras(args.requirements)
 
     if args.pip_data_exclude:
-        pip_data_exclude = json.loads(args.pip_data_exclude)
+        pip_data_exclude = json.loads(args.pip_data_exclude)["exclude"]
     else:
         pip_data_exclude = []
 


### PR DESCRIPTION
This can be used to extend the list of exclusions for Bazel packages
generated from pip wheels.