### PR TITLE
Use JSON to communicate extra_pip_args to extract_wheels

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -37,7 +37,7 @@ def _pip_repository_impl(rctx):
     if rctx.attr.extra_pip_args:
         args += [
             "--extra_pip_args",
-            "\"" + " ".join(rctx.attr.extra_pip_args) + "\"",
+            struct(args = rctx.attr.extra_pip_args).to_json(),
         ]
 
     if rctx.attr.pip_data_exclude:

--- a/extract_wheels/__init__.py
+++ b/extract_wheels/__init__.py
@@ -75,7 +75,7 @@ def main() -> None:
 
     pip_args = [sys.executable, "-m", "pip", "wheel", "-r", args.requirements]
     if args.extra_pip_args:
-        pip_args += args.extra_pip_args.strip("\"").split()
+        pip_args += json.loads(args.extra_pip_args)["args"]
     # Assumes any errors are logged by pip so do nothing. This command will fail if pip fails
     subprocess.run(pip_args, check=True)
 


### PR DESCRIPTION
Backports fix from #43.
This is safer than constructing a string ourselves.