### PR TITLE
Added path separator dependent on system

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -22,7 +22,8 @@ def _pip_repository_impl(rctx):
         rctx.path(Label("@" + repo + "//:BUILD.bazel")).dirname
         for repo in all_requirements
     ]
-    pypath = ":".join([str(p) for p in [rules_root] + thirdparty_roots])
+    separator = ";" if rctx.os.name.lower().find("windows") != -1 else ":"
+    pypath = separator.join([str(p) for p in [rules_root] + thirdparty_roots])
 
     args = [
         python_interpreter,

--- a/defs.bzl
+++ b/defs.bzl
@@ -22,7 +22,7 @@ def _pip_repository_impl(rctx):
         rctx.path(Label("@" + repo + "//:BUILD.bazel")).dirname
         for repo in all_requirements
     ]
-    separator = ";" if rctx.os.name.lower().find("windows") != -1 else ":"
+    separator = ":" if not "windows" in rctx.os.name.lower() else ";"
     pypath = separator.join([str(p) for p in [rules_root] + thirdparty_roots])
 
     args = [


### PR DESCRIPTION
On Windows, there is a different path separator: ```;``` instead of ```:```.

Using ```:``` as a separator is not working on Windows, so ```;``` should be used. Fortunately, we know which system is being used currently so we can set the separator accordingly.